### PR TITLE
Add a script to build a custom driver which enables middle click scroll with the Trackpoint/Clickpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ Changes to these settings will be lost upon rebooting. To make them permanent, a
 To learn more about the Synaptics Touchpad settings, see:
 
 http://linux.die.net/man/5/synaptics
+
+TrackPoint Middle ClickPad Scrolling
+====================================
+
+Out of the box, the Trackpoint driver does not support scrolling when the middle ClickPad "button" is clicked. An Arch user (esrevinu) made a driver for Arch Linux which supports this functionality, and subsequently some Ubuntu users on Launchpad (dalcde, T_send) wrote a script to help install this driver and its dependencies on Ubuntu. To build and install the driver, you can run the `build_middle_click_driver.sh` script. Note that there may be some conflicts with the `99-synaptics-t440s.conf` configuration file in this repo, so you may need to adjust that.
+
+You can see the full discussion on [Launchpad](https://bugs.launchpad.net/ubuntu/+source/xserver-xorg-input-evdev/+bug/1246683).

--- a/build_middle_click_driver.sh
+++ b/build_middle_click_driver.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+sudo apt-get install libevdev-dev libevdev2
+sudo apt-get build-dep xserver-xorg-input-evdev xserver-xorg-input-synaptics
+
+wget https://launchpad.net/ubuntu/+archive/primary/+files/xserver-xorg-input-evdev_2.9.0.orig.tar.gz
+wget https://launchpad.net/ubuntu/+archive/primary/+files/xserver-xorg-input-evdev_2.9.0-1ubuntu1.diff.gz
+wget https://launchpad.net/ubuntu/+archive/primary/+files/xserver-xorg-input-evdev_2.9.0-1ubuntu1.dsc
+
+wget https://launchpad.net/ubuntu/+archive/primary/+files/xserver-xorg-input-synaptics_1.8.0.orig.tar.gz
+wget https://launchpad.net/ubuntu/+archive/primary/+files/xserver-xorg-input-synaptics_1.8.0-1~exp2ubuntu2.diff.gz
+wget https://launchpad.net/ubuntu/+archive/primary/+files/xserver-xorg-input-synaptics_1.8.0-1~exp2ubuntu2.dsc
+
+dpkg-source -x --no-check xserver-xorg-input-evdev_2.9.0-1ubuntu1.dsc
+dpkg-source -x --no-check xserver-xorg-input-synaptics_1.8.0-1~exp2ubuntu2.dsc
+
+wget https://aur.archlinux.org/packages/xf/xf86-input-evdev-trackpoint/xf86-input-evdev-trackpoint.tar.gz
+
+tar -xzf xf86-input-evdev-trackpoint.tar.gz
+
+mv xf86-input-evdev-trackpoint arch
+mv xserver-xorg-input-evdev-2.9.0 evdev
+mv xserver-xorg-input-synaptics-1.8.0 synaptics
+
+cp synaptics/src/{eventcomm.c,eventcomm.h,properties.c,synaptics.c,synapticsstr.h,synproto.c,synproto.h} evdev/src
+cp synaptics/include/synaptics-properties.h evdev/src
+cp arch/*.patch evdev
+
+cd evdev
+patch -p1 -i 0001-implement-trackpoint-wheel-emulation.patch
+patch -p1 -i 0004-disable-clickpad_guess_clickfingers.patch
+patch -p1 -i 0006-add-synatics-files-into-Makefile.am.patch
+
+dpkg-buildpackage
+
+cd ..
+sudo dpkg -i xserver-xorg-input-evdev_*.deb
+sudo apt-get remove xserver-xorg-input-synaptics
+
+sudo mkdir /etc/X11/xorg.conf.d/
+sudo cp arch/90-evdev-trackpoint.conf /etc/X11/xorg.conf.d
+
+echo If everything was OK, than logout/reboot and enjoy fully working ThinkPad Trackpoint/ClickPad
+echo If you want to deactivate touch area of ClickPad for pure TrackPoint usage
+echo edit /etc/X11/xorg.conf.d/90-evdev-trackpoint.conf and change "0" to "1" at line
+echo Option "AreaBottomEdge" "0"

--- a/build_middle_click_driver.sh
+++ b/build_middle_click_driver.sh
@@ -37,7 +37,7 @@ cd ..
 sudo dpkg -i xserver-xorg-input-evdev_*.deb
 sudo apt-get remove xserver-xorg-input-synaptics
 
-sudo mkdir /etc/X11/xorg.conf.d/
+sudo mkdir -p /etc/X11/xorg.conf.d/
 sudo cp arch/90-evdev-trackpoint.conf /etc/X11/xorg.conf.d
 
 echo If everything was OK, than logout/reboot and enjoy fully working ThinkPad Trackpoint/ClickPad


### PR DESCRIPTION
Got this script from https://bugs.launchpad.net/ubuntu/+source/xserver-xorg-input-evdev/+bug/1246683/comments/50 and I thought you might want to have it here. All credit to the guys who wrote the script on that launchpad bug.
